### PR TITLE
correção no caractere "invisivel" do html

### DIFF
--- a/app/src/rtf/charset.module.js
+++ b/app/src/rtf/charset.module.js
@@ -258,5 +258,9 @@ module.exports = [
     {
         htmlEntity: '&deg;',
         rtfEscapeChar: '\\\'b0'
+    },
+    {
+        htmlEntity: '\u200B',
+        rtfEscapeChar: ''
     }
 ];


### PR DESCRIPTION
Em alguns códigos em html, a tag _“&#8203;”_ é criada porém ela não aparece explicitamente, portanto foi adicionado aos charsets o código em hexa da mesma.
![image](https://user-images.githubusercontent.com/49988864/97577267-f5eef380-19cd-11eb-9a91-0c8251d40792.png)
![image (1)](https://user-images.githubusercontent.com/49988864/97577268-f7202080-19cd-11eb-95df-c1a9a76b3e25.png)
